### PR TITLE
Release v0.005-TRIAL to CPAN

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,12 @@ Revision history for VM-JiffyBox
  
 {{$NEXT}}
 
+0.005     2013-06-10 11:51:12 Europe/Berlin
+          (TRIAL) Updated author email
+          access setter correctly
+          test for build url for api (get_details)
+          fix backwards-compatibility issue with Moo regarding defaults
+
 0.004     2013-06-06 21:52:59 Europe/Berlin
           (TRIAL) Dist::Zilla is used more heavily for building dist
           basic skel of hypervisor implemented (JiffyBox)

--- a/dist.ini
+++ b/dist.ini
@@ -5,7 +5,7 @@ copyright_holder = Tim Schwarz, Boris Däppen, plusW
 copyright_year   = 2013
 
 ; we should replace this wit [AutoVersion] later
-version = 0.004
+version = 0.005
 
 ; inlude a helpful set of basic plugins
 ; this will run all tests for each build!


### PR DESCRIPTION
Hi,

please update master, since I made a new release to CPAN.

```
https://metacpan.org/release/BORISD/VM-JiffyBox-0.005-TRIAL
```

I just updated the Changes-File an the dist.ini.
See the Changes-File for what has changed, since the last release.

I did this, so that our bugfixes for the Moo-defaults can be checked by others.

Regards
Boris
